### PR TITLE
Add HTTP redirection from web to websecure in Traefik configuration

### DIFF
--- a/traefik/traefik.swarm.yml
+++ b/traefik/traefik.swarm.yml
@@ -8,6 +8,11 @@ api:
 entryPoints:
   web:
     address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
   websecure:
     address: ":443"
 

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -8,6 +8,11 @@ api:
 entryPoints:
   web:
     address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
   websecure:
     address: ":443"
 


### PR DESCRIPTION
Implement HTTP redirection to ensure traffic from the web entry point is securely redirected to the websecure entry point.